### PR TITLE
Add Tellur USB Power Strip alias 3 outlet + USB powerstrip

### DIFF
--- a/custom_components/tuya_local/devices/tellur_usb_power_strip.yaml
+++ b/custom_components/tuya_local/devices/tellur_usb_power_strip.yaml
@@ -1,0 +1,93 @@
+name: 3 outlet + USB powerstrip
+primary_entity:
+  entity: switch
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 2
+      type: boolean
+      name: switch
+    - id: 3
+      type: boolean
+      name: switch
+    - id: 7
+      type: boolean
+      name: switch
+secondary_entities:
+  - entity: switch
+    class: outlet
+    name: Outlet 1
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+  - entity: switch
+    class: outlet
+    name: Outlet 2
+    dps:
+      - id: 2
+        type: boolean
+        name: switch
+  - entity: switch
+    class: outlet
+    name: Outlet 3
+    dps:
+      - id: 3
+        type: boolean
+        name: switch
+  - entity: switch
+    name: USB
+    icon: "mdi:usb"
+    dps:
+      - id: 7
+        type: boolean
+        name: switch
+  - entity: number
+    name: Timer outlet 1
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 101
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 0
+          max: 86400
+  - entity: number
+    name: Timer outlet 2
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 0
+          max: 86400
+  - entity: number
+    name: Timer outlet 3
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 103
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 0
+          max: 86400
+  - entity: number
+    name: Timer USB
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 105
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 0
+          max: 86400


### PR DESCRIPTION
This one is similar to the already existing "4 outlet + USB powerstrip" in `logicom_powerstrip.yaml`.

Is there a way to add this general switch. My selected way is not working...
![Screenshot_20221128-172558_Tuya Smart](https://user-images.githubusercontent.com/428567/204329773-4a6ff0ac-6d96-453e-8bbe-7a66bf5f9407.jpg)
